### PR TITLE
Python 3.10 fix

### DIFF
--- a/plugins/blender/__init__.py
+++ b/plugins/blender/__init__.py
@@ -10,9 +10,7 @@ from bpy.utils import unregister_class
 bl_info = {
     "name": "Cast Support",
     "author": "DTZxPorter",
-
     "version": (0, 90, 5),
-
     "blender": (2, 90, 0),
     "location": "File > Import",
     "description": "Import Cast",

--- a/plugins/blender/__init__.py
+++ b/plugins/blender/__init__.py
@@ -10,7 +10,7 @@ from bpy.utils import unregister_class
 bl_info = {
     "name": "Cast Support",
     "author": "DTZxPorter",
-    "version": (0, 90, 1),
+    "version": (0, 90, 5),
     "blender": (2, 90, 0),
     "location": "File > Import",
     "description": "Import Cast",

--- a/plugins/blender/import_cast.py
+++ b/plugins/blender/import_cast.py
@@ -152,7 +152,7 @@ def importModelNode(model, path):
         meshObj = bpy.data.objects.new(mesh.Name() or "CastMesh", newMesh)
 
         vertexPositions = mesh.VertexPositionBuffer()
-        newMesh.vertices.add(len(vertexPositions) / 3)
+        newMesh.vertices.add(int(len(vertexPositions) / 3))
         newMesh.vertices.foreach_set("co", vertexPositions)
 
         faces = mesh.FaceBuffer()
@@ -164,7 +164,7 @@ def importModelNode(model, path):
                              for x in range(0, faceIndicesCount, 3)])
 
         newMesh.loops.add(faceIndicesCount)
-        newMesh.polygons.add(facesCount)
+        newMesh.polygons.add(int(facesCount))
 
         newMesh.loops.foreach_set("vertex_index", faces)
         newMesh.polygons.foreach_set(

--- a/plugins/blender/import_cast.py
+++ b/plugins/blender/import_cast.py
@@ -209,8 +209,8 @@ def importModelNode(model, path):
 
         if skeletonObj is not None:
             boneGroups = []
-            for bone in skeletonObj.pose.bones:
-                boneGroups.append(meshObj.vertex_groups.new(name=bone.name))
+            for bone in model.Skeleton().Bones():
+                boneGroups.append(meshObj.vertex_groups.new(name=bone.Name()))
 
             meshObj.parent = skeletonObj
             modifier = meshObj.modifiers.new('Armature Rig', 'ARMATURE')


### PR DESCRIPTION
Python 3.10 no longer implicitly converts floats to int's, fixes Blender 3.1 compatibility.