### PR TITLE
Add symlinks to `cast.py` in plugins directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,8 +350,6 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 *.zip
-plugins/blender/cast.py
-plugins/maya/cast.py
 .DS_Store
 copy_changes.sh
 copy_changes.ps1

--- a/generate_releases.ps1
+++ b/generate_releases.ps1
@@ -4,9 +4,7 @@ New-Item -Force -Path "./.releases" -Name "maya" -ItemType "directory"
 New-Item -Force -Path "./.releases" -Name "upload" -ItemType "directory"
 
 Copy-item -Force -Recurse -Verbose "./plugins/blender/*" "./.releases/io_scene_cast/"
-Copy-item -Force -Recurse -Verbose "./libraries/python/*" "./.releases/io_scene_cast/"
 Copy-item -Force -Recurse -Verbose "./plugins/maya/*" "./.releases/maya/"
-Copy-item -Force -Recurse -Verbose "./libraries/python/*" "./.releases/maya/"
 
 Compress-Archive -Force -Path "./.releases/io_scene_cast" -DestinationPath "./.releases/upload/blender_cast_plugin.zip"
 Compress-Archive -Force -Path "./.releases/maya/*.py" -DestinationPath "./.releases/upload/maya_cast_plugin.zip"

--- a/generate_releases.sh
+++ b/generate_releases.sh
@@ -5,9 +5,7 @@ mkdir -p ./.releases/maya
 mkdir -p ./.releases/upload
 
 cp -r ./plugins/blender/* ./.releases/io_scene_cast/
-cp -r ./libraries/python/* ./.releases/io_scene_cast/
 cp -r ./plugins/maya/* ./.releases/maya/
-cp -r ./libraries/python/* ./.releases/maya/
 
 ditto -c -k --sequesterRsrc --keepParent ./.releases/io_scene_cast/ ./.releases/upload/blender_cast_plugin.zip
 ditto -c -k --sequesterRsrc ./.releases/maya/ ./.releases/upload/maya_cast_plugin.zip

--- a/plugins/blender/cast.py
+++ b/plugins/blender/cast.py
@@ -1,0 +1,1 @@
+../../libraries/python/cast.py

--- a/plugins/maya/cast.py
+++ b/plugins/maya/cast.py
@@ -1,0 +1,1 @@
+../../libraries/python/cast.py


### PR DESCRIPTION
This is mainly to get the Blender extension to be *closer* of a state where it can be debugged with debugpy in VSCode.

On Windows symlinks either require an elevated CMD or Developer Mode to be enabled (obviously symlinks should be enabled in git config as well), otherwise the files will just become "regular" files after cloning.