### PR TITLE
Support multiple color layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Cast ids are stored as integers to make it faster to serialize and deserialize.
 		<td>False</td>
  	</tr>
 	 <tr>
-  		<td>Vertex Color Buffer (vc)</td>
+  		<td>Vertex Color Buffer (c%d)</td>
    		<td>Integer 32 (i)</td>
 		<td>True</td>
 		<td>False</td>
@@ -233,6 +233,12 @@ Cast ids are stored as integers to make it faster to serialize and deserialize.
    		<td>Integer 32 (i), Short (h), Byte (b)</td>
 		<td>True</td>
 		<td>True</td>
+ 	</tr>
+	<tr>
+  		<td>Color Layer Count (cl)</td>
+   		<td>Integer 32 (i), Short (h), Byte (b)</td>
+		<td>False</td>
+		<td>True if has color layers else False</td>
  	</tr>
 	 <tr>
   		<td>UV Layer Count (ul)</td>
@@ -267,6 +273,9 @@ Cast ids are stored as integers to make it faster to serialize and deserialize.
 - Each vertex descriptor buffer must contain the same number of elements ex: if you have 16 vertices, you must have 16 normals if they exist, 16 colors if the buffer exists. Otherwise it's assumed they are default / skipped.
 - Weights are additive which means having the same bone with `0.5` and `0.5` would end up making that bones influence `1.0` for example.
 - The default skinning method is `linear`. When set to `quaternion` dual quaternion skinning is used.
+- **NEW 8/18/2024**: The vertex color specification has **changed**, in order to support multiple color layers, a new `Color Layer Count (cl)` was added which mimics the `UV Layer Count (ul)` property.
+  - To be backwards compatible, cast processors should check for `cl`, and use that by default along with the new `c%d` layer properties.
+  - If the `cl` property does not exist, a processor should check for the legacy `vc` property which is the one and only color layer if it exists.
 
 ### Blend Shape:
 <table>

--- a/libraries/dotnet/Cast.cs
+++ b/libraries/dotnet/Cast.cs
@@ -872,6 +872,27 @@ namespace Cast
         }
 
         /// <summary>
+        /// Gets the number of color layers in this mesh.
+        /// </summary>
+        /// <returns></returns>
+        public int ColorLayerCount()
+        {
+            if (Properties.TryGetValue("cl", out CastProperty Value))
+            {
+                return (int)Value.Values[0];
+            }
+
+            // Check for old cast vertex color format.
+            // If it exists, always return 1 layer.
+            if (Properties.ContainsKey("vc"))
+            {
+                return 1;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
         /// The collection of faces for this mesh.
         /// </summary>
         /// <returns></returns>
@@ -932,18 +953,34 @@ namespace Cast
         }
 
         /// <summary>
-        /// The collection of vertex colors for this mesh.
+        /// The vertex color layer collection for the given layer index.
         /// </summary>
+        /// <param name="Index">The color layer index, starting from 0</param>
         /// <returns></returns>
-        public IEnumerable<uint> VertexColorBuffer()
+        public IEnumerable<uint> VertexColorBuffer(int index)
         {
-            if (Properties.TryGetValue("vc", out CastProperty Value))
+            if (Properties.TryGetValue("c" + index, out CastProperty Value))
             {
                 foreach (var Item in Value.Values)
                 {
                     yield return (uint)Item;
                 }
             }
+
+            // Support old cast vertex color specification.
+            // If the user asks for index[0], return the original vertex colors.
+            if (index == 0)
+            {
+                if (Properties.TryGetValue("vc", out CastProperty Value))
+                {
+                    foreach (var Item in Value.Values)
+                    {
+                        yield return (uint)Item;
+                    }
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/libraries/python/cast.py
+++ b/libraries/python/cast.py
@@ -586,14 +586,31 @@ class Mesh(CastNode):
 
     def UVLayerCount(self):
         """Gets the number of uv layers in this mesh."""
-        uc = self.properties.get("ul")
-        if uc is not None:
-            return uc.values[0]
+        ul = self.properties.get("ul")
+        if ul is not None:
+            return ul.values[0]
         return 0
 
     def SetUVLayerCount(self, count):
         """Sets the number of uv layers in this mesh."""
         self.CreateProperty("ul", "b").values = [count]
+
+    def ColorLayerCount(self):
+        """Gets the number of color layers in this mesh."""
+        cl = self.properties.get("cl")
+        if cl is not None:
+            return cl.values[0]
+
+        # Check for old cast vertex color format.
+        # If it exists, always return 1 layer.
+        if "vc" in self.properties:
+            return 1
+        else:
+            return 0
+
+    def SetColorLayerCount(self, count):
+        """Sets the number of color layers in this mesh."""
+        self.CreateProperty("cl", "b").values = [count]
 
     def MaximumWeightInfluence(self):
         """The maximum weight influence for this mesh."""
@@ -662,16 +679,23 @@ class Mesh(CastNode):
         """Sets the collection of vertex tangents for this mesh."""
         self.CreateProperty("vt", "3v").values = list(sum(values, ()))
 
-    def VertexColorBuffer(self):
-        """The collection of vertex colors for this mesh."""
-        vc = self.properties.get("vc")
-        if vc is not None:
-            return vc.values
+    def VertexColorLayerBuffer(self, index):
+        """The vertex color layer collection for the given layer index."""
+        cl = self.properties.get("c%d" % index)
+        if cl is not None:
+            return cl.values
+
+        # Support old cast vertex color specification.
+        # If the user asks for index[0], return the original vertex colors.
+        if index == 0:
+            vc = self.properties.get("vc")
+            if vc is not None:
+                return vc.values
         return None
 
-    def SetVertexColorBuffer(self, values):
-        """Sets the collection of vertex colors for this mesh."""
-        self.CreateProperty("vc", "i").values = list(values)
+    def SetVertexColorBuffer(self, index, values):
+        """Sets the vertex color layer collection for the given layer index."""
+        self.CreateProperty("c%d" % index, "i").values = list(values)
 
     def VertexUVLayerBuffer(self, index):
         """The uv layer collection for the given layer index."""

--- a/plugins/blender/__init__.py
+++ b/plugins/blender/__init__.py
@@ -11,7 +11,7 @@ from bpy.utils import unregister_class
 bl_info = {
     "name": "Cast Support",
     "author": "DTZxPorter",
-    "version": (1, 6, 3),
+    "version": (1, 6, 4),
     "blender": (3, 0, 0),
     "location": "File > Import",
     "description": "Import & Export Cast",

--- a/plugins/blender/import_cast.py
+++ b/plugins/blender/import_cast.py
@@ -508,7 +508,7 @@ def importModelNode(self, model, path, selectedObject):
                 [(uvBuffer[x * 2], 1.0 - uvBuffer[(x * 2) + 1]) for x in faces]))
 
         for i in range(mesh.ColorLayerCount()):
-            vertexColors = mesh.VertexColorBuffer(i)
+            vertexColors = mesh.VertexColorLayerBuffer(i)
             newMesh.vertex_colors.new(do_init=False)
             newMesh.vertex_colors[i].data.foreach_set(
                 "color", unpack_list([CastColor.fromInteger(vertexColors[x]) for x in faces]))

--- a/plugins/blender/import_cast.py
+++ b/plugins/blender/import_cast.py
@@ -507,10 +507,10 @@ def importModelNode(self, model, path, selectedObject):
             newMesh.uv_layers[i].data.foreach_set("uv", unpack_list(
                 [(uvBuffer[x * 2], 1.0 - uvBuffer[(x * 2) + 1]) for x in faces]))
 
-        vertexColors = mesh.VertexColorBuffer()
-        if vertexColors is not None:
+        for i in range(mesh.ColorLayerCount()):
+            vertexColors = mesh.VertexColorBuffer(i)
             newMesh.vertex_colors.new(do_init=False)
-            newMesh.vertex_colors[0].data.foreach_set(
+            newMesh.vertex_colors[i].data.foreach_set(
                 "color", unpack_list([CastColor.fromInteger(vertexColors[x]) for x in faces]))
 
         vertexNormals = mesh.VertexNormalBuffer()

--- a/plugins/maya/castplugin.py
+++ b/plugins/maya/castplugin.py
@@ -33,7 +33,7 @@ sceneSettings = {
 }
 
 # Shared version number
-version = "1.63"
+version = "1.64"
 
 
 def utilityAbout():

--- a/plugins/maya/castplugin.py
+++ b/plugins/maya/castplugin.py
@@ -1303,7 +1303,7 @@ def importModelNode(model, path):
 
         colorLayerCount = mesh.ColorLayerCount()
         for i in xrange(colorLayerCount):
-            colorLayer = mesh.VertexColorBuffer(i)
+            colorLayer = mesh.VertexColorLayerBuffer(i)
             scriptUtil = OpenMaya.MScriptUtil()
             scriptUtil.createFromList(
                 [x for xs in [CastColor.fromInteger(x) for x in colorLayer] for x in xs], len(colorLayer) * 4)
@@ -1311,11 +1311,7 @@ def importModelNode(model, path):
             vertexColorBuffer = OpenMaya.MColorArray(
                 scriptUtil.asFloat4Ptr(), len(colorLayer))
 
-            if i > 0:
-                newColorName = newMesh.createColorSetWithName(
-                    "color%d" % (i + 1))
-            else:
-                newColorName = newMesh.currentColorSetName()
+            newColorName = newMesh.createColorSetWithName("color%d" % i)
 
             newMesh.setCurrentColorSetName(newColorName)
             newMesh.setVertexColors(vertexColorBuffer, vertexIndexBuffer)

--- a/plugins/maya/castplugin.py
+++ b/plugins/maya/castplugin.py
@@ -1301,15 +1301,23 @@ def importModelNode(model, path):
 
             newMesh.setVertexNormals(vertexNormalBuffer, vertexIndexBuffer)
 
-        vertexColors = mesh.VertexColorBuffer()
-        if vertexColors is not None:
+        colorLayerCount = mesh.ColorLayerCount()
+        for i in xrange(colorLayerCount):
+            colorLayer = mesh.VertexColorBuffer(i)
             scriptUtil = OpenMaya.MScriptUtil()
             scriptUtil.createFromList(
-                [x for xs in [CastColor.fromInteger(x) for x in vertexColors] for x in xs], len(vertexColors) * 4)
+                [x for xs in [CastColor.fromInteger(x) for x in colorLayer] for x in xs], len(colorLayer) * 4)
 
             vertexColorBuffer = OpenMaya.MColorArray(
-                scriptUtil.asFloat4Ptr(), len(vertexColors))
+                scriptUtil.asFloat4Ptr(), len(colorLayer))
 
+            if i > 0:
+                newColorName = newMesh.createColorSetWithName(
+                    "color%d" % (i + 1))
+            else:
+                newColorName = newMesh.currentColorSetName()
+
+            newMesh.setCurrentColorSetName(newColorName)
             newMesh.setVertexColors(vertexColorBuffer, vertexIndexBuffer)
 
         uvLayerCount = mesh.UVLayerCount()
@@ -1350,7 +1358,7 @@ def importModelNode(model, path):
 
             if i > 0:
                 newUVName = newMesh.createUVSetWithName(
-                    ("map%d" % (i + 1)))
+                    "map%d" % (i + 1))
             else:
                 newUVName = newMesh.currentUVSetName()
 


### PR DESCRIPTION
Add support for multiple color layers.

- Modify Maya/Blender plugins to import all color layers.
- Ensure that cast.py & Cast.cs libraries can load the new color layer format, and fall back gracefully to the legacy format.

Closes #67.