### PR TITLE
Metadata node specification and plugin updates to support up axis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ enum class CastId : uint32_t
 	Material = 0x6C74616D,
 	File = 0x656C6966,
 	Instance = 0x74736E69,
+	Metadata = 0x6174656D,
 };
 ```
 
@@ -1057,6 +1058,59 @@ Cast ids are stored as integers to make it faster to serialize and deserialize.
 		<td>True</td>
 	</tr>
 </table>
+
+### Metadata:
+<table>
+	<tr>
+		<th>Field</th>
+		<th>Type(s)</th>
+		<th>IsArray</th>
+		<th>Required</th>
+ 	</tr>
+ 	<tr>
+  		<td>Children</td>
+   		<td>None</td>
+		<td>True</td>
+		<td>False</td>
+ 	</tr>
+	<tr>
+  		<td>Parent</td>
+   		<td>Root</td>
+		<td>False</td>
+		<td>True</td>
+ 	</tr>
+</table>
+<table>
+	<tr>
+		<th>Property (id)</th>
+		<th>Type(s)</th>
+		<th>IsArray</th>
+		<th>Required</th>
+ 	</tr>
+	<tr>
+  		<td>Author (a)</td>
+   		<td>String (s)</td>
+		<td>False</td>
+		<td>False</td>
+ 	</tr>
+	<tr>
+  		<td>Software (s)</td>
+   		<td>String (s)</td>
+		<td>False</td>
+		<td>False</td>
+ 	</tr>
+	<tr>
+  		<td>Up Axis (up)</td>
+   		<td>String (s) [x, y, z]</td>
+		<td>False</td>
+		<td>False</td>
+ 	</tr>
+</table>
+
+**Notes:**
+- `Author` and `Software` are just for tagging cast files and have no use outside of metadata.
+- `Up Axis` can be used as a hint to software to adjust the scene to match a specific up axis.
+- A cast file can have any number of meta nodes but properties designed for hinting should only use the first metadata node instance.
 
 <br>
 

--- a/libraries/python/cast.py
+++ b/libraries/python/cast.py
@@ -169,6 +169,13 @@ class CastNode(object):
         self.hash = castNextHash()
         self.parentNode = None
 
+    def ChildOfType(self, pType):
+        """Finds the first child that matches the given type."""
+        for x in self.childNodes:
+            if x.__class__ is pType:
+                return x
+        return None
+
     def ChildrenOfType(self, pType):
         """Finds all children that match the given type."""
         return [x for x in self.childNodes if x.__class__ is pType]

--- a/libraries/python/cast.py
+++ b/libraries/python/cast.py
@@ -1261,6 +1261,46 @@ class Instance(CastNode):
         self.CreateProperty("s", "3v").values = list(scale)
 
 
+class Metadata(CastNode):
+    """A collection of metadata for a cast scene."""
+
+    def __init__(self):
+        super(Metadata, self).__init__(0x6174656D)
+
+    def Author(self):
+        """The author of this scene."""
+        author = self.properties.get("a")
+        if author is not None:
+            return author.values[0]
+        return None
+
+    def SetAuthor(self, author):
+        """Sets the author of this scene."""
+        self.CreateProperty("a", "s").values = [author]
+
+    def Software(self):
+        """The software that created this scene."""
+        software = self.properties.get("s")
+        if software is not None:
+            return software.values[0]
+        return None
+
+    def SetSoftware(self, software):
+        """Sets the software that created this scene."""
+        self.CreateProperty("s", "s").values = [software]
+
+    def UpAxis(self):
+        """The up axis for this scene."""
+        up = self.properties.get("up")
+        if up is not None:
+            return up.values[0]
+        return None
+
+    def SetUpAxis(self, up):
+        """Sets the up axis for this scene."""
+        self.CreateProperty("up", "s").values = [up]
+
+
 class Root(CastNode):
     """A root node."""
 
@@ -1278,6 +1318,10 @@ class Root(CastNode):
     def CreateInstance(self):
         """Creates a new instance node."""
         return self.CreateChild(Instance())
+
+    def CreateMetadata(self):
+        """Creates a new metadata node."""
+        return self.CreateChild(Metadata())
 
 
 typeSwitcher = {
@@ -1297,6 +1341,7 @@ typeSwitcher = {
     0x6C74616D: Material,
     0x656C6966: File,
     0x74736E69: Instance,
+    0x6174656D: Metadata,
 }
 
 

--- a/plugins/blender/__init__.py
+++ b/plugins/blender/__init__.py
@@ -11,7 +11,7 @@ from bpy.utils import unregister_class
 bl_info = {
     "name": "Cast Support",
     "author": "DTZxPorter",
-    "version": (1, 6, 4),
+    "version": (1, 6, 5),
     "blender": (3, 0, 0),
     "location": "File > Import",
     "description": "Import & Export Cast",

--- a/plugins/blender/__init__.py
+++ b/plugins/blender/__init__.py
@@ -118,6 +118,7 @@ class ExportCast(bpy.types.Operator, ExportHelper):
     bl_label = "Export Cast"
     bl_description = "Export a Cast file"
     bl_options = {'PRESET'}
+    bl_version = bl_info["version"]
 
     filename_ext = ".cast"
     filter_glob: StringProperty(default="*.cast", options={'HIDDEN'})
@@ -142,6 +143,9 @@ class ExportCast(bpy.types.Operator, ExportHelper):
     scale: FloatProperty(
         name="Scale", description="Apply a scale modifier to any meshes, bones, or animation data", default=1.0)
 
+    up_axis: EnumProperty(
+        name="Up", description="Override the up axis for this scene", items=[("y", "Y Up", "The Y axis points up"), ("z", "Z Up", "The Z axis points up")], default="y")
+
     def draw(self, context):
         self.layout.prop(self, "export_selected")
         self.layout.prop(self, "incl_model")
@@ -149,6 +153,7 @@ class ExportCast(bpy.types.Operator, ExportHelper):
         self.layout.prop(self, "incl_notetracks")
         self.layout.prop(self, "is_looped")
         self.layout.prop(self, "scale")
+        self.layout.prop(self, "up_axis")
 
     def execute(self, context):
         from . import export_cast

--- a/plugins/blender/export_cast.py
+++ b/plugins/blender/export_cast.py
@@ -287,8 +287,10 @@ def exportModel(self, context, root, armatureOrMesh, filepath):
 
             meshNode.SetUVLayerCount(len(vertexUVLayers))
 
-            if len(vertexColorLayers) > 0:
-                meshNode.SetVertexColorBuffer(vertexColorLayers[0])
+            for colorLayer, vertexColors in enumerate(vertexColorLayers):
+                meshNode.SetVertexColorBuffer(colorLayer, vertexColors)
+
+            meshNode.SetColorLayerCount(len(vertexColorLayers))
 
             meshNode.SetFaceBuffer(faceBuffer)
 

--- a/plugins/blender/export_cast.py
+++ b/plugins/blender/export_cast.py
@@ -479,6 +479,14 @@ def save(self, context, filepath=""):
     cast = Cast()
     root = cast.CreateRoot()
 
+    meta = root.CreateMetadata()
+    meta.SetSoftware("Cast v%d.%d%d for Blender v%d.%d.%d" %
+                     (self.bl_version[0], self.bl_version[1], self.bl_version[2],
+                      bpy.app.version[0], bpy.app.version[1], bpy.app.version[2]))
+
+    if self.up_axis:
+        meta.SetUpAxis(self.up_axis)
+
     if self.incl_animation:
         # Check that the selected object is an 'ARMATURE' if we're exporting selected animations.
         if self.export_selected and (selectedObject is not None and selectedObject.type != 'ARMATURE'):


### PR DESCRIPTION
- Support exporting up axis information in blender (user specified).
- Support import and export of up axis information in maya (y, and z only).
- Support basic metadata from blender/maya including cast version/software version.

This still needs import up axis support for blender, but blender requires transforming the scene itself so we'll need to work out the best way to do this in a non-destructive manor.

Closes #68.