### PR TITLE
Error fixing

### DIFF
--- a/plugins/cinema4d/import_cast.pyp
+++ b/plugins/cinema4d/import_cast.pyp
@@ -7,7 +7,7 @@ from c4d import plugins, Vector, Vector4d, CPolygon, gui, BaseObject
 
 PLUGIN_ID = 1062992
 PLUGIN_RES_DIR = os.path.join(os.path.dirname(__file__), "res")
-
+mxutils.ImportSymbols(PLUGIN_RES_DIR)
 with mxutils.LocalImportPath(PLUGIN_RES_DIR):
     from cast import Cast, CastColor, Model, Animation, Instance, File
 
@@ -190,17 +190,19 @@ def importModelNode(doc, node, model, path):
             vnData = vnTag.GetDataAddressW()
 
             for i in range(0, faceIndicesCount, 3):
-                vnTag.Set(vnData, int(i / 3),
-                          Vector(vertexNormals[faces[i] * 3],
-                                 vertexNormals[(faces[i] * 3) + 1],
-                                 -vertexNormals[(faces[i] * 3) + 2]),
-                          Vector(vertexNormals[faces[i] * 3],
-                                 vertexNormals[(faces[i] * 3) + 1],
-                                 -vertexNormals[(faces[i] * 3) + 2]),
-                          Vector(vertexNormals[faces[i] * 3],
-                                 vertexNormals[(faces[i] * 3) + 1],
-                                 -vertexNormals[(faces[i] * 3) + 2]),
-                          Vector(0, 0, 0))
+                vnTag.Set(vnData, int(i / 3), 
+                          {"a": Vector(vertexNormals[faces[i] * 3],
+                                       vertexNormals[(faces[i] * 3) + 1],
+                                       -vertexNormals[(faces[i] * 3) + 2]),
+                            "b": Vector(vertexNormals[faces[i + 1] * 3],
+                                        vertexNormals[(faces[i + 1] * 3) + 1],
+                                        -vertexNormals[(faces[i + 1] * 3) + 2]),
+                            "c": Vector(vertexNormals[faces[i + 2] * 3],
+                                        vertexNormals[(faces[i + 2] * 3) + 1],
+                                        -vertexNormals[(faces[i + 2] * 3) + 2]),
+                            "d": Vector(0, 0, 0)})
+
+
 
             newMesh.InsertTag(vnTag)
 

--- a/plugins/cinema4d/import_cast.pyp
+++ b/plugins/cinema4d/import_cast.pyp
@@ -7,7 +7,9 @@ from c4d import plugins, Vector, Vector4d, CPolygon, gui, BaseObject
 
 PLUGIN_ID = 1062992
 PLUGIN_RES_DIR = os.path.join(os.path.dirname(__file__), "res")
+
 mxutils.ImportSymbols(PLUGIN_RES_DIR)
+
 with mxutils.LocalImportPath(PLUGIN_RES_DIR):
     from cast import Cast, CastColor, Model, Animation, Instance, File
 


### PR DESCRIPTION
The clean up code had following errors:

#1
> NameError:name 'CAST_IMPORT_BIND_SKIN' is not defined

Solution:
`mxutils.ImportSymbols(PLUGIN_RES_DIR)` is required to load the symbols of the res directory.

#2
> vnTag.Set(vnData, int(i / 3),
TypeError:function takes at most 3 arguments (6 given)

Solution:
The third argument of [c4d.NormalTag.Set](https://developers.maxon.net/docs/py/2025_0_0/modules/c4d/C4DAtom/GeListNode/BaseList2D/BaseTag/VariableTag/NormalTag/index.html?highlight=c4d%20normaltag#c4d.NormalTag.Set) has to be a dict