### PR TITLE
Clear notetracks on reset scene

### DIFF
--- a/plugins/maya/castplugin.py
+++ b/plugins/maya/castplugin.py
@@ -124,14 +124,8 @@ def utilityClearNotetracks():
     if cmds.objExists("CastNotetracks"):
         cmds.delete("CastNotetracks")
 
-    if cmds.textScrollList("CastNotetrackList", exists=True):
-        notetracks = cmds.textScrollList(
-            "CastNotetrackList", query=True, allItems=True)
-
-        if notetracks:
-            for note in notetracks:
-                cmds.textScrollList("CastNotetrackList",
-                                    edit=True, removeItem=note)
+    if cmds.textScrollList("CastNotetrackList", query=True, exists=True):
+        cmds.textScrollList("CastNotetrackList", removeAll=True)
 
 
 def utilityCreateNotetrack():


### PR DESCRIPTION
Ensures that all notetracks are cleared when the scene is reset.

Added a check to confirm that the CastNotetrackList exists before querying or modifying it.